### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/forceChains-main/CMakeLists.txt
+++ b/forceChains-main/CMakeLists.txt
@@ -34,7 +34,7 @@ link_libraries(${VTK_LIBRARIES})
 
 # Example
 add_executable(1-single ./examples/1-single.cpp)
-add_executable(3-batch ./examples/3-batch.cpp)
+add_executable(2-filter ./examples/2-filter.cpp)
 add_executable(3-batch ./examples/3-batch.cpp)
 add_executable(4-moving ./examples/4-moving.cpp)
 # pybind11_add_module(forcechain "./src/pybind/userinterface.cpp")

--- a/forceChains-main/examples/1-single.cpp
+++ b/forceChains-main/examples/1-single.cpp
@@ -83,7 +83,7 @@ int main()
     // Calculate force chains
     ui.Run();
 
-    // You exaport chains in CSV or VTP (Paraview) format.
+    // You export chains in CSV or VTP (Paraview) format.
     ui.WriteChainsCsv(outputFile + ".csv", true, ",");
     ui.WriteChainsVtp(outputFile + ".vtp");
 


### PR DESCRIPTION
Minor typo fixed in CMakeLists.txt to generate executable for examples/2-filter.cpp file.